### PR TITLE
Dotnet cmdargs replace

### DIFF
--- a/src/Web/Startup.Mix.cs
+++ b/src/Web/Startup.Mix.cs
@@ -843,6 +843,7 @@ namespace Web
                         {
                             cmd.Print();
                             var cmdArgs = cmd.RightPart(' ');
+                            cmdArgs = ReplaceMyApp(cmdArgs, projectName);
                             PipeProcess(nugetPath, cmdArgs, workDir: hostDir);                        
                         }
                         else

--- a/src/Web/Startup.Mix.cs
+++ b/src/Web/Startup.Mix.cs
@@ -857,6 +857,7 @@ namespace Web
                         {
                             cmd.Print();
                             var cmdArgs = cmd.RightPart(' ');
+                            cmdArgs = ReplaceMyApp(cmdArgs, projectName);
                             PipeProcess(dotnetPath, cmdArgs, workDir: hostDir);                        
                         }
                         else


### PR DESCRIPTION
Add support for using `_init` files with non `$HOST` mix templates.

For example, if a mix template uses:
```
[mix-test](https://gist.github.com/gistlyn/aaaaaaaaaaaaa) {to:'.'} mix test
```

where `mix-test` runs in the root project directory and contains an `_init` contains:

```
dotnet add MyApp/MyApp.csproj package ServiceStack.OrmLite.Sqlite
```

`MyApp/MyApp.csproj` should resolve correctly adding the package to the AppHost project from the root of the solution. 